### PR TITLE
Upgrade to IDEA 2022.1

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -44,4 +44,7 @@ intellij {
 tasks {
     withType<org.jetbrains.intellij.tasks.BuildSearchableOptionsTask>()
         .forEach { it.enabled = false }
+    runIde {
+        maxHeapSize = "1g"
+    }
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,10 +1,10 @@
 plugins {
     java
-    id("org.jetbrains.intellij") version "1.3.0"
+    id("org.jetbrains.intellij") version "1.6.0"
 }
 
 group = "org.jetbrains.research.anticopypaster"
-version = "2021.3-1.0"
+version = "2022.1-1.0"
 
 java {
     sourceCompatibility = JavaVersion.VERSION_11
@@ -18,7 +18,7 @@ val extractMethodProjectName = "org.jetbrains.research.extractMethod"
 
 dependencies {
     implementation("com.google.code.gson:gson:2.8.6")
-    compile("org.apache.commons:commons-lang3:3.0")
+    implementation("org.apache.commons:commons-lang3:3.0")
     implementation("org.pmml4s:pmml4s_2.13:0.9.10")
     implementation("org.tensorflow:tensorflow:1.15.0")
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 org.gradle.jvmargs=-XX:MaxMetaspaceSize=512m
 platformType=IC
-platformVersion=2021.3
+platformVersion=2022.1
 platformDownloadSources=true
 platformPlugins=com.intellij.java

--- a/src/main/java/org/jetbrains/research/anticopypaster/ide/AntiCopyPastePreProcessor.java
+++ b/src/main/java/org/jetbrains/research/anticopypaster/ide/AntiCopyPastePreProcessor.java
@@ -27,7 +27,7 @@ import static org.jetbrains.research.anticopypaster.utils.PsiUtil.getCountOfCode
 public class AntiCopyPastePreProcessor implements CopyPastePreProcessor {
     private final DuplicatesInspection inspection = new DuplicatesInspection();
     private final Timer timer = new Timer(true);
-    private final RefactoringNotificationTask refactoringNotificationTask = new RefactoringNotificationTask(timer);
+    private final RefactoringNotificationTask refactoringNotificationTask = new RefactoringNotificationTask(inspection, timer);
 
     private static final Logger LOG = Logger.getInstance(AntiCopyPastePreProcessor.class);
 

--- a/src/main/java/org/jetbrains/research/anticopypaster/ide/AntiCopyPastePreProcessor.java
+++ b/src/main/java/org/jetbrains/research/anticopypaster/ide/AntiCopyPastePreProcessor.java
@@ -26,7 +26,8 @@ import static org.jetbrains.research.anticopypaster.utils.PsiUtil.getCountOfCode
  */
 public class AntiCopyPastePreProcessor implements CopyPastePreProcessor {
     private final DuplicatesInspection inspection = new DuplicatesInspection();
-    private final RefactoringNotificationTask refactoringNotificationTask = new RefactoringNotificationTask();
+    private final Timer timer = new Timer(true);
+    private final RefactoringNotificationTask refactoringNotificationTask = new RefactoringNotificationTask(timer);
 
     private static final Logger LOG = Logger.getInstance(AntiCopyPastePreProcessor.class);
 
@@ -86,7 +87,6 @@ public class AntiCopyPastePreProcessor implements CopyPastePreProcessor {
      */
     private void setCheckingForRefactoringOpportunities() {
         try {
-            Timer timer = new Timer();
             timer.schedule(refactoringNotificationTask, 15000, 15000);
         } catch (Exception ex) {
             LOG.error("[ACP] Failed to schedule the checking for refactorings.", ex.getMessage());

--- a/src/main/java/org/jetbrains/research/anticopypaster/ide/DuplicatesInspection.java
+++ b/src/main/java/org/jetbrains/research/anticopypaster/ide/DuplicatesInspection.java
@@ -11,15 +11,15 @@ import com.intellij.psi.util.PsiTreeUtil;
 import org.apache.commons.lang.StringUtils;
 import org.jetbrains.annotations.NotNull;
 
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.Objects;
 import java.util.concurrent.Executors;
-import java.util.concurrent.Future;
 import java.util.concurrent.ThreadPoolExecutor;
+import java.util.stream.Collectors;
 
 public final class DuplicatesInspection {
-    private static ThreadPoolExecutor pool = (ThreadPoolExecutor) Executors.newFixedThreadPool(8);
+    private static final ThreadPoolExecutor pool = (ThreadPoolExecutor) Executors.newFixedThreadPool(8);
 
     private static final Logger LOG = Logger.getInstance(AntiCopyPastePreProcessor.class);
 
@@ -34,52 +34,21 @@ public final class DuplicatesInspection {
      * @return the result of duplicates' detection.
      */
     public InspectionResult resolve(PsiFile file, final String code) {
-        final ArrayList<Future<DuplicateResult>> tasks = new ArrayList<>();
         final List<String> tokensOfPastedCode = getTokens(code);
         @NotNull Collection<PsiMethod> methods = PsiTreeUtil.findChildrenOfType(file, PsiMethod.class);
-        for (PsiMethod psiMethod : methods) {
-            tasks.add(
-                    pool.submit(() -> ApplicationManager.getApplication().runReadAction(new Computable<DuplicateResult>() {
-                        @Override
-                        public DuplicateResult compute() {
-                            DuplicateResult duplicateResult = null;
-                            PsiCodeBlock methodBody = psiMethod.getBody();
-                            if (methodBody != null) {
-                                String rawCode =
-                                        code.replace('\n', ' ').replace('\t', ' ')
-                                                .replace('\r', ' ').replaceAll("\\s+", "");
-                                String rawMethodBody = psiMethod.getText().replace('\n', ' ').replace('\t', ' ')
-                                        .replace('\r', ' ').replaceAll("\\s+", "");
-                                boolean matches = StringUtils.contains(rawMethodBody, rawCode);
-                                if (matches) {
-                                    duplicateResult = new DuplicateResult(psiMethod, 1.0);
-                                } else {
-                                    List<String> tokensOfMethod = getTokens(methodBody.getText());
-                                    double maxNumOfTokens = Math.max(tokensOfPastedCode.size(), tokensOfMethod.size());
-                                    // Calculates the intersection of tokens
-                                    tokensOfMethod.retainAll(tokensOfPastedCode);
-                                    double threshold = tokensOfMethod.size() / maxNumOfTokens;
-                                    if (threshold >= 0.8) {
-                                        duplicateResult = new DuplicateResult(psiMethod, threshold);
-                                    }
-                                }
-                            }
-                            return duplicateResult;
-                        }
-                    })));
-        }
-
-        ArrayList<DuplicateResult> results = new ArrayList<>();
-        for (Future<DuplicateResult> future : tasks) {
-            try {
-                DuplicateResult result = future.get();
-                if (result != null)
-                    results.add(result);
-            } catch (Exception e) {
-                LOG.warn("[ACP] Failed while searching for code duplicates.", e);
-            }
-        }
-
+        final List<DuplicateResult> results = methods.stream()
+                .map(method -> new DuplicateResultComputable(code, method, tokensOfPastedCode))
+                .map(computable -> pool.submit(() -> ApplicationManager.getApplication().runReadAction(computable)))
+                .map(future -> {
+                    try {
+                        return future.get();
+                    } catch (Exception e) {
+                        LOG.warn("[ACP] Failed while searching for code duplicates.", e);
+                        return null;
+                    }
+                })
+                .filter(Objects::nonNull)
+                .collect(Collectors.toList());
         return new InspectionResult(results);
     }
 
@@ -94,9 +63,9 @@ public final class DuplicatesInspection {
     }
 
     public static class InspectionResult {
-        private final ArrayList<DuplicateResult> results;
+        private final List<DuplicateResult> results;
 
-        public InspectionResult(ArrayList<DuplicateResult> results) {
+        public InspectionResult(List<DuplicateResult> results) {
             this.results = results;
         }
 
@@ -105,7 +74,46 @@ public final class DuplicatesInspection {
         }
     }
 
-    private List<String> getTokens(String text) {
+    private static class DuplicateResultComputable implements Computable<DuplicateResult> {
+        private final String code;
+        private final PsiMethod psiMethod;
+        private final List<String> tokensOfPastedCode;
+
+        private DuplicateResultComputable(String code, PsiMethod psiMethod, List<String> tokensOfPastedCode) {
+            this.code = code;
+            this.psiMethod = psiMethod;
+            this.tokensOfPastedCode = tokensOfPastedCode;
+        }
+
+        @Override
+        public DuplicateResult compute() {
+            DuplicateResult duplicateResult = null;
+            PsiCodeBlock methodBody = psiMethod.getBody();
+            if (methodBody != null) {
+                String rawCode =
+                        code.replace('\n', ' ').replace('\t', ' ')
+                                .replace('\r', ' ').replaceAll("\\s+", "");
+                String rawMethodBody = psiMethod.getText().replace('\n', ' ').replace('\t', ' ')
+                        .replace('\r', ' ').replaceAll("\\s+", "");
+                boolean matches = StringUtils.contains(rawMethodBody, rawCode);
+                if (matches) {
+                    duplicateResult = new DuplicateResult(psiMethod, 1.0);
+                } else {
+                    List<String> tokensOfMethod = getTokens(methodBody.getText());
+                    double maxNumOfTokens = Math.max(tokensOfPastedCode.size(), tokensOfMethod.size());
+                    // Calculates the intersection of tokens
+                    tokensOfMethod.retainAll(tokensOfPastedCode);
+                    double threshold = tokensOfMethod.size() / maxNumOfTokens;
+                    if (threshold >= 0.8) {
+                        duplicateResult = new DuplicateResult(psiMethod, threshold);
+                    }
+                }
+            }
+            return duplicateResult;
+        }
+    }
+
+    private static List<String> getTokens(String text) {
         return StringUtil.getWordsIn(text);
     }
 }

--- a/src/main/java/org/jetbrains/research/anticopypaster/ide/DuplicatesInspection.java
+++ b/src/main/java/org/jetbrains/research/anticopypaster/ide/DuplicatesInspection.java
@@ -19,9 +19,9 @@ import java.util.concurrent.ThreadPoolExecutor;
 import java.util.stream.Collectors;
 
 public final class DuplicatesInspection {
-    private static final ThreadPoolExecutor pool = (ThreadPoolExecutor) Executors.newFixedThreadPool(8);
-
     private static final Logger LOG = Logger.getInstance(AntiCopyPastePreProcessor.class);
+
+    private final ThreadPoolExecutor pool = (ThreadPoolExecutor) Executors.newFixedThreadPool(8);
 
     /**
      * Searches for duplicates in methods extracted from the file.

--- a/src/main/java/org/jetbrains/research/anticopypaster/ide/RefactoringNotificationTask.java
+++ b/src/main/java/org/jetbrains/research/anticopypaster/ide/RefactoringNotificationTask.java
@@ -37,15 +37,12 @@ public class RefactoringNotificationTask extends TimerTask {
     private static final float predictionThreshold = 0.5f; // certainty threshold for models
     private final DuplicatesInspection inspection = new DuplicatesInspection();
     private final ConcurrentLinkedQueue<RefactoringEvent> eventsQueue = new ConcurrentLinkedQueue<>();
-    private final NotificationGroup NOTIFICATION_GROUP = NotificationGroupManager.getInstance()
+    private final NotificationGroup notificationGroup = NotificationGroupManager.getInstance()
             .getNotificationGroup("Extract Method suggestion");
-
-    public RefactoringNotificationTask() {
-    }
+    private final PredictionModel model = new TensorflowModel();
 
     @Override
     public void run() {
-        PredictionModel model = new TensorflowModel();
         while (!eventsQueue.isEmpty()) {
             try {
                 final RefactoringEvent event = eventsQueue.poll();
@@ -133,7 +130,7 @@ public class RefactoringNotificationTask extends TimerTask {
     }
 
     public void notify(Project project, String content, Runnable callback) {
-        final Notification notification = NOTIFICATION_GROUP.createNotification(content, NotificationType.INFORMATION);
+        final Notification notification = notificationGroup.createNotification(content, NotificationType.INFORMATION);
         notification.setListener(new NotificationListener.Adapter() {
             @Override
             protected void hyperlinkActivated(@NotNull Notification notification, @NotNull HyperlinkEvent e) {

--- a/src/main/java/org/jetbrains/research/anticopypaster/ide/RefactoringNotificationTask.java
+++ b/src/main/java/org/jetbrains/research/anticopypaster/ide/RefactoringNotificationTask.java
@@ -33,14 +33,12 @@ import static org.jetbrains.research.anticopypaster.utils.PsiUtil.*;
  * Shows a notification about discovered Extract Method refactoring opportunity.
  */
 public class RefactoringNotificationTask extends TimerTask {
-    private static final Double predictionThreshold = 0.5; // certainty threshold for models
-    private final ConcurrentLinkedQueue<RefactoringEvent> eventsQueue = new ConcurrentLinkedQueue<>();
-    private static final DuplicatesInspection inspection = new DuplicatesInspection();
-    private final NotificationGroup NOTIFICATION_GROUP = new NotificationGroup("Extract Method suggestion",
-            NotificationDisplayType.BALLOON,
-            true);
-
     private static final Logger LOG = Logger.getInstance(RefactoringNotificationTask.class);
+    private static final float predictionThreshold = 0.5f; // certainty threshold for models
+    private final DuplicatesInspection inspection = new DuplicatesInspection();
+    private final ConcurrentLinkedQueue<RefactoringEvent> eventsQueue = new ConcurrentLinkedQueue<>();
+    private final NotificationGroup NOTIFICATION_GROUP = NotificationGroupManager.getInstance()
+            .getNotificationGroup("Extract Method suggestion");
 
     public RefactoringNotificationTask() {
     }
@@ -83,7 +81,7 @@ public class RefactoringNotificationTask extends TimerTask {
                     }
                 });
             } catch (Exception e) {
-                LOG.error("[ACP] Can't process an event" + e.getMessage());
+                LOG.error("[ACP] Can't process an event " + e.getMessage());
             }
         }
     }

--- a/src/main/java/org/jetbrains/research/anticopypaster/ide/RefactoringNotificationTask.java
+++ b/src/main/java/org/jetbrains/research/anticopypaster/ide/RefactoringNotificationTask.java
@@ -23,6 +23,7 @@ import org.jetbrains.research.extractMethod.metrics.features.FeaturesVector;
 import javax.swing.event.HyperlinkEvent;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Timer;
 import java.util.TimerTask;
 import java.util.concurrent.ConcurrentLinkedQueue;
 
@@ -40,6 +41,11 @@ public class RefactoringNotificationTask extends TimerTask {
     private final NotificationGroup notificationGroup = NotificationGroupManager.getInstance()
             .getNotificationGroup("Extract Method suggestion");
     private final PredictionModel model = new TensorflowModel();
+    private final Timer timer;
+
+    public RefactoringNotificationTask(Timer timer) {
+        this.timer = timer;
+    }
 
     @Override
     public void run() {
@@ -140,8 +146,8 @@ public class RefactoringNotificationTask extends TimerTask {
         notification.notify(project);
     }
 
-    private static void scheduleExtraction(Project project, PsiFile file, Editor editor, String text) {
-        new java.util.Timer().schedule(
+    private void scheduleExtraction(Project project, PsiFile file, Editor editor, String text) {
+        timer.schedule(
                 new ExtractionTask(editor, file, text, project),
                 100
         );

--- a/src/main/java/org/jetbrains/research/anticopypaster/models/TensorflowNativeLibraryLoader.java
+++ b/src/main/java/org/jetbrains/research/anticopypaster/models/TensorflowNativeLibraryLoader.java
@@ -1,0 +1,161 @@
+package org.jetbrains.research.anticopypaster.models;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * This class fixes loading of native library in case
+ * the classloader does not provide package version info
+ */
+final class TensorflowNativeLibraryLoader {
+    private static final String JNI_LIBNAME = "tensorflow_jni";
+    private static final String TENSORFLOW_VERSION = "1.15.0";
+    private static final AtomicBoolean executed = new AtomicBoolean();
+
+    public static void load() {
+        if (!executed.compareAndSet(false, true)) {
+            return; // was previously called
+        }
+        // Native code has been packaged into the .jar file containing this.
+        // Extract the JNI library itself
+        final String jniLibName = System.mapLibraryName(JNI_LIBNAME);
+        final String jniResourceName = makeResourceName(jniLibName);
+        final InputStream jniResource =
+                TensorflowNativeLibraryLoader.class.getClassLoader().getResourceAsStream(jniResourceName);
+        // Extract the JNI's dependency
+        final String frameworkLibName =
+                getVersionedLibraryName(System.mapLibraryName("tensorflow_framework"));
+        final String frameworkResourceName = makeResourceName(frameworkLibName);
+        final InputStream frameworkResource =
+                TensorflowNativeLibraryLoader.class.getClassLoader().getResourceAsStream(frameworkResourceName);
+        // Do not complain if the framework resource wasn't found. This may just mean that we're
+        // building with --config=monolithic (in which case it's not needed and not included).
+        if (jniResource == null) {
+            throw new UnsatisfiedLinkError(
+                    String.format(
+                            "Cannot find TensorFlow native library for OS: %s, architecture: %s. See "
+                                    + "https://github.com/tensorflow/tensorflow/tree/master/tensorflow/java/README.md"
+                                    + " for possible solutions (such as building the library from source). Additional"
+                                    + " information on attempts to find the native library can be obtained by adding"
+                                    + " org.tensorflow.NativeLibrary.DEBUG=1 to the system properties of the JVM.",
+                            os(), architecture()));
+        }
+        try {
+            // Create a temporary directory for the extracted resource and its dependencies.
+            final File tempPath = Files.createTempDirectory("tensorflow_native_libraries-").toFile();
+            // Deletions are in the reverse order of requests, so we need to request that the directory be
+            // deleted first, so that it is empty when the request is fulfilled.
+            tempPath.deleteOnExit();
+            final String tempDirectory = tempPath.getCanonicalPath();
+            if (frameworkResource != null) {
+                extractResource(frameworkResource, frameworkLibName, tempDirectory);
+            }
+            System.load(extractResource(jniResource, jniLibName, tempDirectory));
+        } catch (IOException e) {
+            throw new UnsatisfiedLinkError(
+                    String.format(
+                            "Unable to extract native library into a temporary file (%s)", e.toString()));
+        }
+    }
+
+    private static boolean resourceExists(String baseName) {
+        return TensorflowNativeLibraryLoader.class.getClassLoader().getResource(makeResourceName(baseName)) != null;
+    }
+
+    private static String getVersionedLibraryName(String libFilename) {
+        // If the resource exists as an unversioned file, return that.
+        if (resourceExists(libFilename)) {
+            return libFilename;
+        }
+
+        final String versionName = getMajorVersionNumber();
+
+        // If we're on darwin, the versioned libraries look like blah.1.dylib.
+        final String darwinSuffix = ".dylib";
+        if (libFilename.endsWith(darwinSuffix)) {
+            final String prefix = libFilename.substring(0, libFilename.length() - darwinSuffix.length());
+            if (versionName != null) {
+                final String darwinVersionedLibrary = prefix + "." + versionName + darwinSuffix;
+                if (resourceExists(darwinVersionedLibrary)) {
+                    return darwinVersionedLibrary;
+                }
+            } else {
+                // If we're here, we're on darwin, but we couldn't figure out the major version number. We
+                // already tried the library name without any changes, but let's do one final try for the
+                // library with a .so suffix.
+                final String darwinSoName = prefix + ".so";
+                if (resourceExists(darwinSoName)) {
+                    return darwinSoName;
+                }
+            }
+        } else if (libFilename.endsWith(".so")) {
+            // Libraries ending in ".so" are versioned like "libfoo.so.1", so try that.
+            final String versionedSoName = libFilename + "." + versionName;
+            if (versionName != null && resourceExists(versionedSoName)) {
+                return versionedSoName;
+            }
+        }
+
+        // Otherwise, we've got no idea.
+        return libFilename;
+    }
+
+    /**
+     * Returns the major version number of this TensorFlow Java API, or {@code null} if it cannot be
+     * determined.
+     */
+    private static String getMajorVersionNumber() {
+        String version = TensorflowNativeLibraryLoader.class.getPackage().getImplementationVersion();
+        // expecting a string like 1.14.0, we want to get the first '1'.
+        if (version == null) {
+            version = TENSORFLOW_VERSION; // classloader does not provide package information
+        }
+        int dotIndex = version.indexOf('.');
+        if (dotIndex == -1) {
+            return null; // invalid version string
+        }
+        String majorVersion = version.substring(0, dotIndex);
+        try {
+            Integer.parseInt(majorVersion);
+            return majorVersion;
+        } catch (NumberFormatException unused) {
+            return null;
+        }
+    }
+
+    private static String extractResource(
+            InputStream resource, String resourceName, String extractToDirectory) throws IOException {
+        final File dst = new File(extractToDirectory, resourceName);
+        dst.deleteOnExit();
+        final String dstPath = dst.toString();
+        Files.copy(resource, dst.toPath());
+        return dstPath;
+    }
+
+    private static String os() {
+        final String p = System.getProperty("os.name").toLowerCase();
+        if (p.contains("linux")) {
+            return "linux";
+        } else if (p.contains("os x") || p.contains("darwin")) {
+            return "darwin";
+        } else if (p.contains("windows")) {
+            return "windows";
+        } else {
+            return p.replaceAll("\\s", "");
+        }
+    }
+
+    private static String architecture() {
+        final String arch = System.getProperty("os.arch").toLowerCase();
+        return (arch.equals("amd64")) ? "x86_64" : arch;
+    }
+
+    private static String makeResourceName(String baseName) {
+        return "org/tensorflow/native/" + String.format("%s-%s/", os(), architecture()) + baseName;
+    }
+
+    private TensorflowNativeLibraryLoader() {}
+}

--- a/src/main/java/org/jetbrains/research/anticopypaster/utils/PsiUtil.java
+++ b/src/main/java/org/jetbrains/research/anticopypaster/utils/PsiUtil.java
@@ -6,14 +6,13 @@ import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.editor.Document;
 import com.intellij.openapi.editor.Editor;
 import com.intellij.openapi.project.Project;
-import com.intellij.openapi.vcs.VcsException;
 import com.intellij.openapi.vcs.changes.Change;
 import com.intellij.openapi.vcs.changes.ChangeListManager;
 import com.intellij.openapi.vcs.changes.ContentRevision;
 import com.intellij.psi.*;
 import com.intellij.psi.util.PsiTreeUtil;
-import com.intellij.refactoring.introduceVariable.IntroduceVariableBase;
-import com.intellij.refactoring.util.RefactoringUtil;
+import com.intellij.refactoring.IntroduceVariableUtil;
+import com.intellij.util.CommonJavaRefactoringUtil;
 import org.apache.commons.lang3.StringUtils;
 import org.jetbrains.annotations.NotNull;
 
@@ -118,9 +117,9 @@ public class PsiUtil {
             elements = CodeInsightUtil.findStatementsInRange(file, startOffset, endOffset);
             if (elements.length == 0) {
                 final PsiExpression expression =
-                        IntroduceVariableBase.getSelectedExpression(project, file, startOffset, endOffset);
-                if (expression != null && IntroduceVariableBase.getErrorMessage(expression) == null) {
-                    final PsiType originalType = RefactoringUtil.getTypeByExpressionWithExpectedType(expression);
+                        IntroduceVariableUtil.getSelectedExpression(project, file, startOffset, endOffset);
+                if (expression != null && IntroduceVariableUtil.getErrorMessage(expression) == null) {
+                    final PsiType originalType = CommonJavaRefactoringUtil.getTypeByExpressionWithExpectedType(expression);
                     if (originalType != null) {
                         elements = new PsiElement[]{expression};
                     }

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -14,5 +14,7 @@
 
     <extensions defaultExtensionNs="com.intellij">
         <copyPastePreProcessor implementation="org.jetbrains.research.anticopypaster.ide.AntiCopyPastePreProcessor"/>
+        <notificationGroup id="Extract Method suggestion"
+                           displayType="BALLOON"/>
     </extensions>
 </idea-plugin>

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -2,7 +2,7 @@
     <id>org.jetbrains.research.anticopypaster</id>
     <name>AntiCopyPaster</name>
     <vendor>JetBrains</vendor>
-    <version>2021.3-1.0</version>
+    <version>2022.1-1.0</version>
 
     <description><![CDATA[
     Tracks the copying and pasting actions and suggests extracting duplicates into a new method. Based on imbalanced-pruned experiment.


### PR DESCRIPTION
Resolves #20 

Fixed the following defects illuminated after upgrade:
1. Read-only file system in MacOS: WORKDIR was modified so model was attempted to be copied to root dir (`/`). Fix: copy the model to plugin directory (`idea.plugins.path`)
2. UnsatisfiedLinkError while loading tensorflow native libraries: the plugin classloader returns `null` as package information so tensorflow version failed to be retrieved. Fix: load tensorflow native libraries by the plugin